### PR TITLE
Push param and values into separate spawn args

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ function buildArgs(options, defaults) {
       if (value === true) {
         args.push('--' + name)
       } else if (value !== false) {
-        args.push('--' + name + '=' + value);
+        args.push('--' + name)
+        args.push(value);
       }
     }
     args.push('-')


### PR DESCRIPTION
otherwise it will crash wkhtml

experienced with wkhtmltopdf 0.12.1 (with patched qt)
Example params output:

```
[ '-',
  '--print-media-type',
  '--header-spacing 3',
  '--footer-right "[page] / [toPage]"',
  '-' ]
  --> GET /quotation/55861e3e23ab66d4549759e7?format=pdf 200 1,233ms 12b
events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: write EPIPE
    at exports._errnoException (util.js:742:11)
    at Object.afterWrite (net.js:749:14)
12 Jul 09:39:42 - [nodemon] app crashed - waiting for file changes before starting...
```
